### PR TITLE
Removed `val` parameter from `reset_set` and `boot_set`

### DIFF
--- a/iis2dlpc_reg.c
+++ b/iis2dlpc_reg.c
@@ -898,11 +898,10 @@ int32_t iis2dlpc_auto_increment_get(const stmdev_ctx_t *ctx, uint8_t *val)
   * @brief  Software reset. Restore the default values in user registers.[set]
   *
   * @param  ctx      read / write interface definitions
-  * @param  val      change the values of soft_reset in reg CTRL2
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dlpc_reset_set(const stmdev_ctx_t *ctx, uint8_t val)
+int32_t iis2dlpc_reset_set(const stmdev_ctx_t *ctx)
 {
   iis2dlpc_ctrl2_t reg;
   int32_t ret;
@@ -911,7 +910,7 @@ int32_t iis2dlpc_reset_set(const stmdev_ctx_t *ctx, uint8_t val)
 
   if (ret == 0)
   {
-    reg.soft_reset = val;
+    reg.soft_reset = PROPERTY_ENABLE;
     ret = iis2dlpc_write_reg(ctx, IIS2DLPC_CTRL2, (uint8_t *) &reg, 1);
   }
 
@@ -941,11 +940,10 @@ int32_t iis2dlpc_reset_get(const stmdev_ctx_t *ctx, uint8_t *val)
   * @brief  Reboot memory content. Reload the calibration parameters.[set]
   *
   * @param  ctx      read / write interface definitions
-  * @param  val      change the values of boot in reg CTRL2
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dlpc_boot_set(const stmdev_ctx_t *ctx, uint8_t val)
+int32_t iis2dlpc_boot_set(const stmdev_ctx_t *ctx)
 {
   iis2dlpc_ctrl2_t reg;
   int32_t ret;
@@ -954,7 +952,7 @@ int32_t iis2dlpc_boot_set(const stmdev_ctx_t *ctx, uint8_t val)
 
   if (ret == 0)
   {
-    reg.boot = val;
+    reg.boot = PROPERTY_ENABLE;
     ret = iis2dlpc_write_reg(ctx, IIS2DLPC_CTRL2, (uint8_t *) &reg, 1);
   }
 


### PR DESCRIPTION
This pull request removes the `val` parameter from the `iis2dlpc_reset_set` and `iis2dlpc_boot_set` functions. The parameter was redundant since the only acceptable value for it was 1. To simplify the code and improve maintainability, the value has been hardcoded as a constant.