### PR TITLE
Fix sensitivity values for LSB to mg conversion

### DIFF
--- a/iis2dlpc_reg.c
+++ b/iis2dlpc_reg.c
@@ -95,42 +95,42 @@ int32_t __weak iis2dlpc_write_reg(const stmdev_ctx_t *ctx, uint8_t reg,
 
 float_t iis2dlpc_from_fs2_to_mg(int16_t lsb)
 {
-  return ((float_t)lsb) * 0.061f;
+  return ((float_t)lsb) * 0.244f;
 }
 
 float_t iis2dlpc_from_fs4_to_mg(int16_t lsb)
 {
-  return ((float_t)lsb) * 0.122f;
+  return ((float_t)lsb) * 0.488f;
 }
 
 float_t iis2dlpc_from_fs8_to_mg(int16_t lsb)
 {
-  return ((float_t)lsb) * 0.244f;
+  return ((float_t)lsb) * 0.976f;
 }
 
 float_t iis2dlpc_from_fs16_to_mg(int16_t lsb)
 {
-  return ((float_t)lsb) * 0.488f;
+  return ((float_t)lsb) * 1.952f;
 }
 
 float_t iis2dlpc_from_fs2_lp1_to_mg(int16_t lsb)
 {
-  return ((float_t)lsb) * 0.061f;
+  return ((float_t)lsb) * 0.976f;
 }
 
 float_t iis2dlpc_from_fs4_lp1_to_mg(int16_t lsb)
 {
-  return ((float_t)lsb) * 0.122f;
+  return ((float_t)lsb) * 1.952f;
 }
 
 float_t iis2dlpc_from_fs8_lp1_to_mg(int16_t lsb)
 {
-  return ((float_t)lsb) * 0.244f;
+  return ((float_t)lsb) * 3.904f;
 }
 
 float_t iis2dlpc_from_fs16_lp1_to_mg(int16_t lsb)
 {
-  return ((float_t)lsb) * 0.488f;
+  return ((float_t)lsb) * 7.808f;
 }
 
 float_t iis2dlpc_from_lsb_to_celsius(int16_t lsb)


### PR DESCRIPTION
Corrected conversion factors to align with IIS2DLPC datasheet specifications.